### PR TITLE
Fix inet rails 7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,6 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in ip_net_active_record_type.gemspec
 gemspec
+
+gem 'rake', '~> 10.0'
+gem 'minitest', '~> 5.0'

--- a/ip_net_active_record_type.gemspec
+++ b/ip_net_active_record_type.gemspec
@@ -19,9 +19,5 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 2.1.1'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'minitest', '~> 5.0'
-
   spec.add_dependency 'activemodel', '>= 5.0'
 end

--- a/lib/ip_net_active_record_type.rb
+++ b/lib/ip_net_active_record_type.rb
@@ -1,3 +1,4 @@
+require 'active_support/all'
 require 'ip_net_active_record_type/version'
 require 'ip_net_active_record_type/ip_net'
 require 'ip_net_active_record_type/ip_net_type'

--- a/lib/ip_net_active_record_type/ip_net_type.rb
+++ b/lib/ip_net_active_record_type/ip_net_type.rb
@@ -16,7 +16,7 @@ module IpNetActiveRecordType
     end
 
     def serialize(value)
-      value.to_s
+      value&.to_s
     end
 
     private

--- a/lib/ip_net_active_record_type/version.rb
+++ b/lib/ip_net_active_record_type/version.rb
@@ -1,3 +1,3 @@
 module IpNetActiveRecordType
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end

--- a/test/ip_net_active_record_type_test.rb
+++ b/test/ip_net_active_record_type_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'active_support/core_ext/hash/keys'
 
 class IpNetActiveRecordTypeTest < Minitest::Test
 

--- a/test/ip_net_active_record_type_test.rb
+++ b/test/ip_net_active_record_type_test.rb
@@ -123,6 +123,11 @@ class IpNetActiveRecordTypeTest < Minitest::Test
     assert_equal ip_net, type.cast(ip)
   end
 
+  def test_type_nil_value
+    type = IpNetActiveRecordType::IpNetType.new
+    assert_nil type.serialize(nil)
+  end
+
   def test_type_incorrect_value
     type = IpNetActiveRecordType::IpNetType.new
     ip = 'test'


### PR DESCRIPTION
- move development dependencies to Gemfile
- fix for activesupport 7+
- fix null value for postgresql inet type in Rails 7+
 without this fix such error appear when you assign nil to inet attribute
 PG::InvalidTextRepresentation: ERROR:  invalid input syntax for type inet: ""
- bump version 2.1.1